### PR TITLE
Rails 8.0 minimum

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,6 +39,8 @@ jobs:
             rails-version: '~> 7.2.0'
           - ruby-version: '3.3'
             rails-version: '~> 8.0.0'
+          - ruby-version: '3.4'
+            rails-version: '~> 8.0.0'
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,24 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version:
-          - '2.6'
-          - '2.7'
-        rails-version:
-          - "~> 6.1.0"
-          - "~> 6.0.0"
-          - "~> 5.2.0"
         include:
-          - ruby-version: '3.0'
-            rails-version: '~> 6.1.0'
-          - ruby-version: '3.1'
-            rails-version: '~> 7.0.0'
-          - ruby-version: '3.2'
-            rails-version: '~> 7.0.0'
-          - ruby-version: '3.3'
-            rails-version: '~> 7.1.0'
-          - ruby-version: '3.3'
-            rails-version: '~> 7.2.0'
           - ruby-version: '3.3'
             rails-version: '~> 8.0.0'
           - ruby-version: '3.4'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # TASK[BUMP_RUBY] - update ruby version here
-ruby 3.3.5
+ruby 3.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Testing: Added Rails 8.0 on Ruby 3.4 to test matrix
+* Removing support for Ruby versions prior to 3.1.7, and Rails versions prior to 8.0
 
 ## 0.4.2 - 2024-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Testing: Added Rails 8.0 on Ruby 3.4 to test matrix
+
 ## 0.4.2 - 2024-11-10
 
 * Testing: Added Rails 7.0 on Ruby 3.2 to test matrix

--- a/README.md
+++ b/README.md
@@ -107,20 +107,15 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 If you want to test using a specific Rails version locally, use this method:
 
 ``` shell-interaction
-export RAILS_VERSION="~> 5.1" 
+export RAILS_VERSION="~> 8.0" 
 bundle update
 bundle exec rake
 ```
 
 If you prefer a oneliner for testing a combination, try this:
 ```
-(asdf set ruby 2.7.6; export RAILS_VERSION="~> 5.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf set ruby 2.7.6; export RAILS_VERSION="~> 6.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf set ruby 2.7.6; export RAILS_VERSION="~> 6.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf set ruby 3.0.4; export RAILS_VERSION="~> 6.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf set ruby 3.0.4; export RAILS_VERSION="~> 7.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf set ruby 3.1.2; export RAILS_VERSION="~> 7.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf set ruby 3.3.5; export RAILS_VERSION="~> 8.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 3.3.8; export RAILS_VERSION="~> 8.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 3.4.3; export RAILS_VERSION="~> 8.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
 ```
 
 It assumes you have [`asdf`](https://asdf-vm.com/) installed to manage your ruby versions, which is very convenient.

--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ bundle exec rake
 
 If you prefer a oneliner for testing a combination, try this:
 ```
-(asdf shell ruby 2.7.6; export RAILS_VERSION="~> 5.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf shell ruby 2.7.6; export RAILS_VERSION="~> 6.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf shell ruby 2.7.6; export RAILS_VERSION="~> 6.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf shell ruby 3.0.4; export RAILS_VERSION="~> 6.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf shell ruby 3.0.4; export RAILS_VERSION="~> 7.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf shell ruby 3.1.2; export RAILS_VERSION="~> 7.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
-(asdf shell ruby 3.3.5; export RAILS_VERSION="~> 8.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 2.7.6; export RAILS_VERSION="~> 5.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 2.7.6; export RAILS_VERSION="~> 6.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 2.7.6; export RAILS_VERSION="~> 6.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 3.0.4; export RAILS_VERSION="~> 6.1.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 3.0.4; export RAILS_VERSION="~> 7.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 3.1.2; export RAILS_VERSION="~> 7.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
+(asdf set ruby 3.3.5; export RAILS_VERSION="~> 8.0.0"; rm Gemfile.lock; bundle install; bundle exec rake ci)
 ```
 
 It assumes you have [`asdf`](https://asdf-vm.com/) installed to manage your ruby versions, which is very convenient.

--- a/lograge_waittime.gemspec
+++ b/lograge_waittime.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "lograge", "~> 0.10"
   s.add_dependency "request_store", "~> 1.0"
-  s.add_dependency "railties", ">= 5.0" # Need access to Rails::Engine API
+  s.add_dependency "railties", ">= 8.0" # Need access to Rails::Engine API
   s.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
To ease cleaning up and simplifying the setup remove testing of on older Rails versions.